### PR TITLE
feat: add update feed tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,11 @@ To use this MCP server with Claude Desktop, add the following to your Claude Des
 
 The Miniflux MCP Server provides **40+ tools** covering all Miniflux API functionality, which can be found in the [Miniflux API Reference](https://miniflux.app/docs/api.html#go-client).
 
-### Feed Management (10 tools)
+### Feed Management (11 tools)
 - `get_feeds` - Get all RSS/Atom feeds
 - `get_feed` - Get a specific feed by ID
 - `create_feed` - Add a new RSS/Atom feed
+- `update_feed` - Update an existing feed
 - `delete_feed` - Delete a specific feed
 - `refresh_feed` - Manually refresh a specific feed
 - `refresh_all_feeds` - Refresh all feeds

--- a/handlers.go
+++ b/handlers.go
@@ -40,6 +40,105 @@ func (s *MinifluxServer) GetFeed(ctx context.Context, request mcp.CallToolReques
 	return mcp.NewToolResultText(string(feedJSON)), nil
 }
 
+func (s *MinifluxServer) UpdateFeed(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := request.Params.Arguments
+	if args == nil {
+		return mcp.NewToolResultError("feed_id and at least one field to update are required"), nil
+	}
+
+	argsMap, ok := args.(map[string]interface{})
+	if !ok {
+		return mcp.NewToolResultError("Invalid arguments format"), nil
+	}
+
+	feedIDFloat, ok := argsMap["feed_id"].(float64)
+	if !ok {
+		return mcp.NewToolResultError("feed_id must be a number"), nil
+	}
+
+	changes := &client.FeedModificationRequest{}
+	hasChanges := false
+
+	stringFields := map[string]**string{
+		"feed_url":                 &changes.FeedURL,
+		"site_url":                 &changes.SiteURL,
+		"title":                    &changes.Title,
+		"scraper_rules":            &changes.ScraperRules,
+		"rewrite_rules":            &changes.RewriteRules,
+		"urlrewrite_rules":         &changes.UrlRewriteRules,
+		"blocklist_rules":          &changes.BlocklistRules,
+		"keeplist_rules":           &changes.KeeplistRules,
+		"block_filter_entry_rules": &changes.BlockFilterEntryRules,
+		"keep_filter_entry_rules":  &changes.KeepFilterEntryRules,
+		"user_agent":               &changes.UserAgent,
+		"cookie":                   &changes.Cookie,
+		"username":                 &changes.Username,
+		"password":                 &changes.Password,
+		"proxy_url":                &changes.ProxyURL,
+	}
+	for name, target := range stringFields {
+		value, exists := argsMap[name]
+		if !exists {
+			continue
+		}
+		stringValue, ok := value.(string)
+		if !ok {
+			return mcp.NewToolResultError(fmt.Sprintf("%s must be a string", name)), nil
+		}
+		*target = &stringValue
+		hasChanges = true
+	}
+
+	boolFields := map[string]**bool{
+		"crawler":                        &changes.Crawler,
+		"disabled":                       &changes.Disabled,
+		"ignore_http_cache":              &changes.IgnoreHTTPCache,
+		"allow_self_signed_certificates": &changes.AllowSelfSignedCertificates,
+		"fetch_via_proxy":                &changes.FetchViaProxy,
+		"hide_globally":                  &changes.HideGlobally,
+		"disable_http2":                  &changes.DisableHTTP2,
+	}
+	for name, target := range boolFields {
+		value, exists := argsMap[name]
+		if !exists {
+			continue
+		}
+		boolValue, ok := value.(bool)
+		if !ok {
+			return mcp.NewToolResultError(fmt.Sprintf("%s must be a boolean", name)), nil
+		}
+		*target = &boolValue
+		hasChanges = true
+	}
+
+	if value, exists := argsMap["category_id"]; exists {
+		categoryIDFloat, ok := value.(float64)
+		if !ok {
+			return mcp.NewToolResultError("category_id must be a number"), nil
+		}
+		categoryID := int64(categoryIDFloat)
+		changes.CategoryID = &categoryID
+		hasChanges = true
+	}
+
+	if !hasChanges {
+		return mcp.NewToolResultError("at least one field to update is required"), nil
+	}
+
+	feedID := int64(feedIDFloat)
+	updatedFeed, err := s.client.UpdateFeed(feedID, changes)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to update feed: %v", err)), nil
+	}
+
+	feedJSON, err := json.MarshalIndent(updatedFeed, "", "  ")
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal updated feed: %v", err)), nil
+	}
+
+	return mcp.NewToolResultText(string(feedJSON)), nil
+}
+
 func (s *MinifluxServer) DeleteFeed(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := request.Params.Arguments
 	if args == nil {

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"miniflux.app/v2/client"
+)
+
+func TestUpdateFeed(t *testing.T) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("method = %s, want PUT", r.Method)
+		}
+		if r.URL.Path != "/v1/feeds/42" {
+			t.Errorf("path = %s, want /v1/feeds/42", r.URL.Path)
+		}
+
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		if body["category_id"] != float64(7) {
+			t.Errorf("category_id = %#v, want 7", body["category_id"])
+		}
+		if body["title"] != "Updated title" {
+			t.Errorf("title = %#v, want Updated title", body["title"])
+		}
+		if body["crawler"] != false {
+			t.Errorf("crawler = %#v, want false", body["crawler"])
+		}
+		if body["feed_url"] != nil {
+			t.Errorf("feed_url = %#v, want null", body["feed_url"])
+		}
+		if _, exists := body["feed_id"]; exists {
+			t.Errorf("request body must not contain feed_id: %#v", body)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		if err := json.NewEncoder(w).Encode(&client.Feed{
+			ID:       42,
+			Title:    "Updated title",
+			Crawler:  false,
+			Category: &client.Category{ID: 7},
+		}); err != nil {
+			t.Errorf("encode response body: %v", err)
+		}
+	}))
+	defer apiServer.Close()
+
+	minifluxServer := &MinifluxServer{client: client.NewClient(apiServer.URL, "test-api-key")}
+	request := mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Arguments: map[string]interface{}{
+				"feed_id":     float64(42),
+				"category_id": float64(7),
+				"title":       "Updated title",
+				"crawler":     false,
+			},
+		},
+	}
+
+	result, err := minifluxServer.UpdateFeed(context.Background(), request)
+	if err != nil {
+		t.Fatalf("UpdateFeed returned error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("UpdateFeed returned tool error: %#v", result.Content)
+	}
+	if len(result.Content) != 1 {
+		t.Fatalf("result content length = %d, want 1", len(result.Content))
+	}
+
+	textContent, ok := mcp.AsTextContent(result.Content[0])
+	if !ok {
+		t.Fatalf("result content type = %T, want text", result.Content[0])
+	}
+	var updatedFeed client.Feed
+	if err := json.Unmarshal([]byte(textContent.Text), &updatedFeed); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if updatedFeed.ID != 42 || updatedFeed.Category == nil || updatedFeed.Category.ID != 7 {
+		t.Errorf("updated feed = %#v, want feed 42 in category 7", updatedFeed)
+	}
+}
+
+func TestUpdateFeedRequiresAChange(t *testing.T) {
+	minifluxServer := &MinifluxServer{}
+	request := mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Arguments: map[string]interface{}{
+				"feed_id": float64(42),
+			},
+		},
+	}
+
+	result, err := minifluxServer.UpdateFeed(context.Background(), request)
+	if err != nil {
+		t.Fatalf("UpdateFeed returned error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("UpdateFeed succeeded without a field to update")
+	}
+}

--- a/tools.go
+++ b/tools.go
@@ -80,6 +80,115 @@ func (s *MinifluxServer) RegisterAllTools(mcpServer *server.MCPServer) {
 		},
 		{
 			Tool: mcp.Tool{
+				Name:        "update_feed",
+				Description: "Update an existing feed",
+				InputSchema: mcp.ToolInputSchema{
+					Type: "object",
+					Properties: map[string]interface{}{
+						"feed_id": map[string]interface{}{
+							"type":        "number",
+							"description": "The ID of the feed to update",
+						},
+						"feed_url": map[string]interface{}{
+							"type":        "string",
+							"description": "New RSS/Atom feed URL",
+						},
+						"site_url": map[string]interface{}{
+							"type":        "string",
+							"description": "New website URL",
+						},
+						"title": map[string]interface{}{
+							"type":        "string",
+							"description": "New feed title",
+						},
+						"category_id": map[string]interface{}{
+							"type":        "number",
+							"description": "Category ID to move the feed to",
+						},
+						"scraper_rules": map[string]interface{}{
+							"type":        "string",
+							"description": "CSS selectors for scraping article content",
+						},
+						"rewrite_rules": map[string]interface{}{
+							"type":        "string",
+							"description": "Content rewrite rules",
+						},
+						"urlrewrite_rules": map[string]interface{}{
+							"type":        "string",
+							"description": "URL rewrite rules",
+						},
+						"blocklist_rules": map[string]interface{}{
+							"type":        "string",
+							"description": "Entry blocklist rules",
+						},
+						"keeplist_rules": map[string]interface{}{
+							"type":        "string",
+							"description": "Entry keeplist rules",
+						},
+						"block_filter_entry_rules": map[string]interface{}{
+							"type":        "string",
+							"description": "Entry block filter rules",
+						},
+						"keep_filter_entry_rules": map[string]interface{}{
+							"type":        "string",
+							"description": "Entry keep filter rules",
+						},
+						"crawler": map[string]interface{}{
+							"type":        "boolean",
+							"description": "Enable or disable full-content scraping",
+						},
+						"user_agent": map[string]interface{}{
+							"type":        "string",
+							"description": "Custom user agent for feed fetching",
+						},
+						"cookie": map[string]interface{}{
+							"type":        "string",
+							"description": "Cookie header for feed fetching",
+						},
+						"username": map[string]interface{}{
+							"type":        "string",
+							"description": "Username for HTTP basic authentication",
+						},
+						"password": map[string]interface{}{
+							"type":        "string",
+							"description": "Password for HTTP basic authentication",
+						},
+						"disabled": map[string]interface{}{
+							"type":        "boolean",
+							"description": "Enable or disable feed fetching",
+						},
+						"ignore_http_cache": map[string]interface{}{
+							"type":        "boolean",
+							"description": "Ignore HTTP cache headers",
+						},
+						"allow_self_signed_certificates": map[string]interface{}{
+							"type":        "boolean",
+							"description": "Allow self-signed TLS certificates",
+						},
+						"fetch_via_proxy": map[string]interface{}{
+							"type":        "boolean",
+							"description": "Fetch the feed through the configured proxy",
+						},
+						"hide_globally": map[string]interface{}{
+							"type":        "boolean",
+							"description": "Hide feed entries from the global list",
+						},
+						"disable_http2": map[string]interface{}{
+							"type":        "boolean",
+							"description": "Disable HTTP/2 when fetching the feed",
+						},
+						"proxy_url": map[string]interface{}{
+							"type":        "string",
+							"description": "Proxy URL used to fetch the feed",
+						},
+					},
+					Required: []string{"feed_id"},
+				},
+			},
+			Handler: s.UpdateFeed,
+		},
+		{
+			Tool: mcp.Tool{
 				Name:        "delete_feed",
 				Description: "Delete a specific feed",
 				InputSchema: mcp.ToolInputSchema{


### PR DESCRIPTION
## Summary

- Add an `update_feed` MCP tool backed by the Miniflux client.
- Expose supported feed modification fields, including `category_id`.
- Add handler coverage and document the new tool.

Closes #21 