### PR TITLE
feat: extend entry filters

### DIFF
--- a/entries_test.go
+++ b/entries_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"miniflux.app/v2/client"
+)
+
+func TestGetEntriesFilters(t *testing.T) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/v1/entries" {
+			t.Errorf("path = %s, want /v1/entries", r.URL.Path)
+		}
+
+		query := r.URL.Query()
+		expectedValues := map[string]string{
+			"feed_id":          "42",
+			"category_id":      "7",
+			"limit":            "1",
+			"offset":           "2",
+			"published_after":  "1700000000",
+			"published_before": "1700003600",
+			"changed_after":    "1700000100",
+			"changed_before":   "1700003500",
+			"after_entry_id":   "10",
+			"before_entry_id":  "100",
+			"search":           "weather test",
+			"starred":          client.FilterOnlyStarred,
+			"order":            "published_at",
+			"direction":        "desc",
+			"globally_visible": "true",
+		}
+		for name, expected := range expectedValues {
+			if actual := query.Get(name); actual != expected {
+				t.Errorf("%s = %q, want %q", name, actual, expected)
+			}
+		}
+		if actual := query["status"]; !reflect.DeepEqual(actual, []string{"read", "unread"}) {
+			t.Errorf("status = %#v, want read and unread", actual)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(&client.EntryResultSet{Total: 12}); err != nil {
+			t.Errorf("encode response body: %v", err)
+		}
+	}))
+	defer apiServer.Close()
+
+	minifluxServer := &MinifluxServer{client: client.NewClient(apiServer.URL, "test-api-key")}
+	request := mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Arguments: map[string]interface{}{
+				"status":           "removed",
+				"statuses":         []interface{}{"read", "unread"},
+				"feed_id":          float64(42),
+				"category_id":      float64(7),
+				"limit":            float64(1),
+				"offset":           float64(2),
+				"published_after":  float64(1700000000),
+				"published_before": float64(1700003600),
+				"changed_after":    float64(1700000100),
+				"changed_before":   float64(1700003500),
+				"after_entry_id":   float64(10),
+				"before_entry_id":  float64(100),
+				"search":           "weather test",
+				"starred":          true,
+				"order":            "published_at",
+				"direction":        "desc",
+				"globally_visible": true,
+			},
+		},
+	}
+
+	result, err := minifluxServer.GetEntries(context.Background(), request)
+	if err != nil {
+		t.Fatalf("GetEntries returned error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("GetEntries returned tool error: %#v", result.Content)
+	}
+
+	textContent, ok := mcp.AsTextContent(result.Content[0])
+	if !ok {
+		t.Fatalf("result content type = %T, want text", result.Content[0])
+	}
+	var entries client.EntryResultSet
+	if err := json.Unmarshal([]byte(textContent.Text), &entries); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if entries.Total != 12 {
+		t.Errorf("total = %d, want 12", entries.Total)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -79,23 +79,80 @@ func (s *MinifluxServer) GetEntries(ctx context.Context, request mcp.CallToolReq
 		if ok {
 			filter = &client.Filter{}
 
-			if statusStr, ok := argsMap["status"].(string); ok {
+			if statusValues, ok := argsMap["statuses"].([]interface{}); ok {
+				for _, statusValue := range statusValues {
+					if status, ok := statusValue.(string); ok {
+						filter.Statuses = append(filter.Statuses, status)
+					}
+				}
+			}
+
+			if statusStr, ok := argsMap["status"].(string); ok && len(filter.Statuses) == 0 {
 				filter.Status = statusStr
 			}
 
 			if feedIDFloat, ok := argsMap["feed_id"].(float64); ok {
-				feedID := int64(feedIDFloat)
-				filter.FeedID = feedID
+				filter.FeedID = int64(feedIDFloat)
+			}
+
+			if categoryIDFloat, ok := argsMap["category_id"].(float64); ok {
+				filter.CategoryID = int64(categoryIDFloat)
 			}
 
 			if limitFloat, ok := argsMap["limit"].(float64); ok {
-				limit := int(limitFloat)
-				filter.Limit = limit
+				filter.Limit = int(limitFloat)
 			}
 
 			if offsetFloat, ok := argsMap["offset"].(float64); ok {
-				offset := int(offsetFloat)
-				filter.Offset = offset
+				filter.Offset = int(offsetFloat)
+			}
+
+			if publishedAfterFloat, ok := argsMap["published_after"].(float64); ok {
+				filter.PublishedAfter = int64(publishedAfterFloat)
+			}
+
+			if publishedBeforeFloat, ok := argsMap["published_before"].(float64); ok {
+				filter.PublishedBefore = int64(publishedBeforeFloat)
+			}
+
+			if changedAfterFloat, ok := argsMap["changed_after"].(float64); ok {
+				filter.ChangedAfter = int64(changedAfterFloat)
+			}
+
+			if changedBeforeFloat, ok := argsMap["changed_before"].(float64); ok {
+				filter.ChangedBefore = int64(changedBeforeFloat)
+			}
+
+			if beforeEntryIDFloat, ok := argsMap["before_entry_id"].(float64); ok {
+				filter.BeforeEntryID = int64(beforeEntryIDFloat)
+			}
+
+			if afterEntryIDFloat, ok := argsMap["after_entry_id"].(float64); ok {
+				filter.AfterEntryID = int64(afterEntryIDFloat)
+			}
+
+			if search, ok := argsMap["search"].(string); ok {
+				filter.Search = search
+			}
+
+			if starred, ok := argsMap["starred"].(bool); ok {
+				if starred {
+					filter.Starred = client.FilterOnlyStarred
+				} else {
+					filter.Starred = client.FilterNotStarred
+				}
+			}
+
+			if order, ok := argsMap["order"].(string); ok {
+				filter.Order = order
+			}
+
+			if direction, ok := argsMap["direction"].(string); ok {
+				filter.Direction = direction
+			}
+
+			if globallyVisible, ok := argsMap["globally_visible"].(bool); ok {
+				filter.GloballyVisible = globallyVisible
 			}
 		}
 	}

--- a/tools.go
+++ b/tools.go
@@ -328,10 +328,23 @@ func (s *MinifluxServer) RegisterAllTools(mcpServer *server.MCPServer) {
 						"status": map[string]interface{}{
 							"type":        "string",
 							"description": "Filter by entry status (read, unread, removed)",
+							"enum":        []string{"read", "unread", "removed"},
+						},
+						"statuses": map[string]interface{}{
+							"type":        "array",
+							"description": "Filter by multiple entry statuses; takes precedence over status",
+							"items": map[string]interface{}{
+								"type": "string",
+								"enum": []string{"read", "unread", "removed"},
+							},
 						},
 						"feed_id": map[string]interface{}{
 							"type":        "number",
 							"description": "Filter by specific feed ID",
+						},
+						"category_id": map[string]interface{}{
+							"type":        "number",
+							"description": "Filter by specific category ID",
 						},
 						"limit": map[string]interface{}{
 							"type":        "number",
@@ -340,6 +353,52 @@ func (s *MinifluxServer) RegisterAllTools(mcpServer *server.MCPServer) {
 						"offset": map[string]interface{}{
 							"type":        "number",
 							"description": "Offset for pagination",
+						},
+						"published_after": map[string]interface{}{
+							"type":        "number",
+							"description": "Return entries published after this Unix timestamp",
+						},
+						"published_before": map[string]interface{}{
+							"type":        "number",
+							"description": "Return entries published before this Unix timestamp",
+						},
+						"changed_after": map[string]interface{}{
+							"type":        "number",
+							"description": "Return entries changed after this Unix timestamp",
+						},
+						"changed_before": map[string]interface{}{
+							"type":        "number",
+							"description": "Return entries changed before this Unix timestamp",
+						},
+						"before_entry_id": map[string]interface{}{
+							"type":        "number",
+							"description": "Return entries with an ID lower than this value",
+						},
+						"after_entry_id": map[string]interface{}{
+							"type":        "number",
+							"description": "Return entries with an ID greater than this value",
+						},
+						"search": map[string]interface{}{
+							"type":        "string",
+							"description": "Search entry title and content",
+						},
+						"starred": map[string]interface{}{
+							"type":        "boolean",
+							"description": "Filter by starred state",
+						},
+						"order": map[string]interface{}{
+							"type":        "string",
+							"description": "Field used to sort entries",
+							"enum":        []string{"id", "status", "changed_at", "published_at", "created_at", "category_title", "category_id", "title", "author"},
+						},
+						"direction": map[string]interface{}{
+							"type":        "string",
+							"description": "Sort direction",
+							"enum":        []string{"asc", "desc"},
+						},
+						"globally_visible": map[string]interface{}{
+							"type":        "boolean",
+							"description": "Restrict results to globally visible entries when true",
 						},
 					},
 				},


### PR DESCRIPTION
## Summary

- Expose timestamp, category, search, starred, visibility, cursor, and sorting filters through `get_entries`.
- Support filtering by multiple entry statuses.
- Add coverage for mapping MCP arguments to Miniflux query parameters.

Closes #22