### PR TITLE
feat: add Streamable HTTP transport

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,12 @@ MINIFLUX_API_KEY=your_api_key_here
 # Option 2: Username/password authentication
 # MINIFLUX_USERNAME=your_username
 # MINIFLUX_PASSWORD=your_password
+
+# MCP transport: stdio (default) or streamable-http
+# MCP_TRANSPORT=streamable-http
+# MCP_HTTP_ADDR=:8080
+# MCP_HTTP_PATH=/mcp
+
+# Required when MCP_TRANSPORT=streamable-http.
+# This token protects the remote MCP endpoint and is separate from Miniflux authentication.
+# MCP_AUTH_TOKEN=replace_with_a_strong_secret

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,6 @@ WORKDIR /root/
 
 COPY --from=builder /app/miniflux-mcp .
 
+EXPOSE 8080
+
 CMD ["./miniflux-mcp"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Model Context Protocol (MCP) server for interacting with Miniflux RSS reader. 
 - **Category Management**: List and organize feed categories
 - **Flexible Authentication**: Support for both API key and username/password authentication
 
-## Setup Instructions
+## Setup
 
 ### Getting a Miniflux API Key
 
@@ -18,14 +18,7 @@ A Model Context Protocol (MCP) server for interacting with Miniflux RSS reader. 
 3. Create a new API key
 4. Copy the generated key to your configuration
 
-### Using Docker
-
-```bash
-docker build -t miniflux-mcp .
-docker run --env-file .env miniflux-mcp
-```
-
-### Environment Variables
+### Miniflux Environment Variables
 
 | Variable | Description | Required |
 |----------|-------------|----------|
@@ -36,29 +29,32 @@ docker run --env-file .env miniflux-mcp
 
 *Either use `MINIFLUX_API_KEY` OR both `MINIFLUX_USERNAME` and `MINIFLUX_PASSWORD`
 
-### Getting a Miniflux API Key
+## Local stdio Server
 
-1. Log into your Miniflux instance
-2. Go to Settings → API Keys
-3. Create a new API key
-4. Copy the generated key to your configuration
+`stdio` is the default transport and is intended for an MCP client that starts the server locally.
 
-### Docker Run
+### Using Docker
 
 ```bash
-# Setup .env file
-# Run
+docker build -t miniflux-mcp .
+docker run -i --rm --env-file .env miniflux-mcp
+```
+
+Or use the published image:
+
+```bash
 docker run -i --rm --env-file .env jwonder/miniflux-mcp:latest
 ```
 
-### Integration with Claude Desktop
+### Claude Code (`.mcp.json`)
 
-To use this MCP server with Claude Desktop, add the following to your Claude Desktop configuration:
+Add the following `.mcp.json` file to your project root:
 
-```json5
+```json
 {
   "mcpServers": {
     "miniflux": {
+      "type": "stdio",
       "command": "docker",
       "args": [
         "run",
@@ -71,16 +67,63 @@ To use this MCP server with Claude Desktop, add the following to your Claude Des
         "jwonder/miniflux-mcp:latest"
       ],
       "env": {
-        "MINIFLUX_URL": "https://your-miniflux-instance.com",
-        "MINIFLUX_API_KEY": "your_api_key_here"
-        // Or use username/password instead of API key
-        // "MINIFLUX_USERNAME": "your_username_here",
-        // "MINIFLUX_PASSWORD": "your_password_here"
+        "MINIFLUX_URL": "${MINIFLUX_URL}",
+        "MINIFLUX_API_KEY": "${MINIFLUX_API_KEY}"
       }
     }
   }
 }
 ```
+
+## Remote Streamable HTTP Server
+
+The remote server exposes a Streamable HTTP MCP endpoint protected by a static Bearer token.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `MCP_TRANSPORT` | Set to `streamable-http` | `stdio` |
+| `MCP_HTTP_ADDR` | HTTP listen address | `:8080` |
+| `MCP_HTTP_PATH` | MCP endpoint path | `/mcp` |
+| `MCP_AUTH_TOKEN` | Bearer token protecting the MCP endpoint; required in HTTP mode | None |
+
+Set a strong token and start the container with the Streamable HTTP transport:
+
+```bash
+export MCP_AUTH_TOKEN='replace-with-a-strong-secret'
+
+docker run --rm \
+  -p 8080:8080 \
+  --env-file .env \
+  -e MCP_TRANSPORT=streamable-http \
+  -e MCP_AUTH_TOKEN \
+  jwonder/miniflux-mcp:latest
+```
+
+Configure an MCP client to connect to `http://your-server:8080/mcp` and send:
+
+```http
+Authorization: Bearer replace-with-a-strong-secret
+```
+
+### Claude Code (`.mcp.json`)
+
+Add the remote server to your project-level `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "miniflux": {
+      "type": "http",
+      "url": "https://mcp.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${MCP_AUTH_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+The unauthenticated health endpoint is available at `/healthz`. For deployment outside a trusted private network, put the server behind an HTTPS reverse proxy so the Bearer token is encrypted in transit. One server process uses one configured Miniflux identity, so every connected MCP client has that identity's permissions.
 
 ## Available Tools
 

--- a/e2e/mcp_test.go
+++ b/e2e/mcp_test.go
@@ -8,9 +8,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 )
@@ -36,6 +39,13 @@ type toolCallResult struct {
 		Text string `json:"text"`
 	} `json:"content"`
 	IsError bool `json:"isError"`
+}
+
+type httpRPCClient struct {
+	endpoint string
+	token    string
+	client   *http.Client
+	nextID   int
 }
 
 func (c *rpcClient) request(method string, params any, result any) error {
@@ -84,6 +94,87 @@ func (c *rpcClient) notify(method string) error {
 }
 
 func (c *rpcClient) callTool(name string, arguments map[string]any) (string, error) {
+	var result toolCallResult
+	if err := c.request("tools/call", map[string]any{
+		"name":      name,
+		"arguments": arguments,
+	}, &result); err != nil {
+		return "", err
+	}
+	if result.IsError {
+		return "", fmt.Errorf("%s returned a tool error: %+v", name, result.Content)
+	}
+	for _, content := range result.Content {
+		if content.Type == "text" {
+			return content.Text, nil
+		}
+	}
+	return "", fmt.Errorf("%s returned no text content", name)
+}
+
+func (c *httpRPCClient) request(method string, params any, result any) error {
+	c.nextID++
+	request := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      c.nextID,
+		"method":  method,
+		"params":  params,
+	}
+	return c.send(request, http.StatusOK, result)
+}
+
+func (c *httpRPCClient) notify(method string) error {
+	request := map[string]any{
+		"jsonrpc": "2.0",
+		"method":  method,
+	}
+	return c.send(request, http.StatusAccepted, nil)
+}
+
+func (c *httpRPCClient) send(request map[string]any, expectedStatus int, result any) error {
+	payload, err := json.Marshal(request)
+	if err != nil {
+		return fmt.Errorf("encode %s request: %w", request["method"], err)
+	}
+	httpRequest, err := http.NewRequest(http.MethodPost, c.endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("create %s request: %w", request["method"], err)
+	}
+	httpRequest.Header.Set("Authorization", "Bearer "+c.token)
+	httpRequest.Header.Set("Content-Type", "application/json")
+
+	response, err := c.client.Do(httpRequest)
+	if err != nil {
+		return fmt.Errorf("send %s request: %w", request["method"], err)
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return fmt.Errorf("read %s response: %w", request["method"], err)
+	}
+	if response.StatusCode != expectedStatus {
+		return fmt.Errorf("%s returned HTTP %d: %s", request["method"], response.StatusCode, strings.TrimSpace(string(body)))
+	}
+	if result == nil {
+		return nil
+	}
+
+	var rpcResult rpcResponse
+	if err := json.Unmarshal(body, &rpcResult); err != nil {
+		return fmt.Errorf("decode %s response: %w", request["method"], err)
+	}
+	if rpcResult.Error != nil {
+		return fmt.Errorf("%s failed (%d): %s", request["method"], rpcResult.Error.Code, rpcResult.Error.Message)
+	}
+	if err := json.Unmarshal(rpcResult.Result, result); err != nil {
+		return fmt.Errorf("decode %s result: %w", request["method"], err)
+	}
+	return nil
+}
+
+func (c *httpRPCClient) callTool(name string, arguments map[string]any) (string, error) {
 	var result toolCallResult
 	if err := c.request("tools/call", map[string]any{
 		"name":      name,
@@ -246,6 +337,162 @@ func TestMCPServerWithMiniflux(t *testing.T) {
 
 	if _, err := client.callTool("delete_category", map[string]any{"category_id": category.ID}); err != nil {
 		t.Fatalf("delete category: %v", err)
+	}
+	createdCategoryID = 0
+}
+
+func TestRemoteMCPServerWithMiniflux(t *testing.T) {
+	serverPath := os.Getenv("MCP_SERVER_PATH")
+	if serverPath == "" {
+		t.Fatal("MCP_SERVER_PATH is required")
+	}
+	for _, name := range []string{"MINIFLUX_URL", "MINIFLUX_USERNAME", "MINIFLUX_PASSWORD"} {
+		if os.Getenv(name) == "" {
+			t.Fatalf("%s is required", name)
+		}
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve HTTP port: %v", err)
+	}
+	address := listener.Addr().String()
+	if err := listener.Close(); err != nil {
+		t.Fatalf("release HTTP port: %v", err)
+	}
+
+	const token = "e2e-secret"
+	command := exec.Command(serverPath)
+	command.Env = append(os.Environ(),
+		"MCP_TRANSPORT=streamable-http",
+		"MCP_HTTP_ADDR="+address,
+		"MCP_HTTP_PATH=/mcp",
+		"MCP_AUTH_TOKEN="+token,
+	)
+	var stderr bytes.Buffer
+	command.Stderr = &stderr
+	if err := command.Start(); err != nil {
+		t.Fatalf("start remote MCP server: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- command.Wait()
+	}()
+	t.Cleanup(func() {
+		if command.ProcessState == nil {
+			_ = command.Process.Signal(os.Interrupt)
+		}
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			_ = command.Process.Kill()
+			<-done
+			t.Errorf("remote MCP server did not stop after interrupt")
+		}
+	})
+
+	baseURL := "http://" + address
+	httpClient := &http.Client{Timeout: 5 * time.Second}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		response, requestErr := httpClient.Get(baseURL + "/healthz")
+		if requestErr == nil {
+			_ = response.Body.Close()
+			if response.StatusCode == http.StatusOK {
+				break
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("remote MCP server did not become healthy: %v\n%s", requestErr, stderr.String())
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	unauthorizedRequest, err := http.NewRequest(http.MethodPost, baseURL+"/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`))
+	if err != nil {
+		t.Fatalf("create unauthorized request: %v", err)
+	}
+	unauthorizedRequest.Header.Set("Content-Type", "application/json")
+	unauthorizedResponse, err := httpClient.Do(unauthorizedRequest)
+	if err != nil {
+		t.Fatalf("send unauthorized request: %v", err)
+	}
+	_ = unauthorizedResponse.Body.Close()
+	if unauthorizedResponse.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthorized request returned HTTP %d, want 401", unauthorizedResponse.StatusCode)
+	}
+
+	client := &httpRPCClient{
+		endpoint: baseURL + "/mcp",
+		token:    token,
+		client:   httpClient,
+	}
+	var initialized struct {
+		ProtocolVersion string `json:"protocolVersion"`
+	}
+	if err := client.request("initialize", map[string]any{
+		"protocolVersion": "2024-11-05",
+		"capabilities":    map[string]any{},
+		"clientInfo": map[string]any{
+			"name":    "miniflux-mcp-http-ci",
+			"version": "1.0.0",
+		},
+	}, &initialized); err != nil {
+		t.Fatalf("initialize remote MCP session: %v", err)
+	}
+	if initialized.ProtocolVersion == "" {
+		t.Fatal("initialize response did not include a protocol version")
+	}
+	if err := client.notify("notifications/initialized"); err != nil {
+		t.Fatalf("send initialized notification: %v", err)
+	}
+
+	var listed struct {
+		Tools []struct {
+			Name string `json:"name"`
+		} `json:"tools"`
+	}
+	if err := client.request("tools/list", map[string]any{}, &listed); err != nil {
+		t.Fatalf("list remote tools: %v", err)
+	}
+	toolNames := make([]string, 0, len(listed.Tools))
+	for _, tool := range listed.Tools {
+		toolNames = append(toolNames, tool.Name)
+	}
+	for _, name := range []string{"get_version", "create_category", "delete_category"} {
+		if !slices.Contains(toolNames, name) {
+			t.Fatalf("tools/list did not include %q", name)
+		}
+	}
+
+	title := fmt.Sprintf("mcp-http-e2e-%d", time.Now().UnixNano())
+	categoryText, err := client.callTool("create_category", map[string]any{"title": title})
+	if err != nil {
+		t.Fatalf("create category through remote MCP: %v", err)
+	}
+	var category struct {
+		ID    int64  `json:"id"`
+		Title string `json:"title"`
+	}
+	if err := json.Unmarshal([]byte(categoryText), &category); err != nil {
+		t.Fatalf("decode created category: %v", err)
+	}
+	if category.ID == 0 || category.Title != title {
+		t.Fatalf("created category = %+v, want title %q and a non-zero ID", category, title)
+	}
+	createdCategoryID := category.ID
+	t.Cleanup(func() {
+		if createdCategoryID == 0 {
+			return
+		}
+		if _, err := client.callTool("delete_category", map[string]any{"category_id": createdCategoryID}); err != nil {
+			t.Errorf("clean up category %d: %v", createdCategoryID, err)
+		}
+	})
+
+	if _, err := client.callTool("delete_category", map[string]any{"category_id": category.ID}); err != nil {
+		t.Fatalf("delete category through remote MCP: %v", err)
 	}
 	createdCategoryID = 0
 }

--- a/main.go
+++ b/main.go
@@ -691,18 +691,20 @@ func (s *MinifluxServer) RefreshCategory(ctx context.Context, request mcp.CallTo
 }
 
 func main() {
-	minifluxServer := NewMinifluxServer()
+	transport, err := loadTransportConfig()
+	if err != nil {
+		log.Fatalf("Invalid transport configuration: %v", err)
+	}
 
-	s := server.NewMCPServer(
+	minifluxServer := NewMinifluxServer()
+	mcpServer := server.NewMCPServer(
 		"miniflux-mcp",
 		"0.1.0",
 		server.WithLogging(),
 	)
+	minifluxServer.RegisterAllTools(mcpServer)
 
-	// Register all tools
-	minifluxServer.RegisterAllTools(s)
-
-	if err := server.ServeStdio(s); err != nil {
+	if err := serveMCP(mcpServer, transport); err != nil {
 		log.Fatalf("Server failed: %v", err)
 	}
 }

--- a/transport.go
+++ b/transport.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/mark3labs/mcp-go/server"
+)
+
+const (
+	transportStdio          = "stdio"
+	transportStreamableHTTP = "streamable-http"
+	defaultHTTPAddr         = ":8080"
+	defaultHTTPPath         = "/mcp"
+)
+
+type transportConfig struct {
+	Transport string
+	HTTPAddr  string
+	HTTPPath  string
+	AuthToken string
+}
+
+func loadTransportConfig() (transportConfig, error) {
+	cfg := transportConfig{
+		Transport: envOrDefault("MCP_TRANSPORT", transportStdio),
+		HTTPAddr:  envOrDefault("MCP_HTTP_ADDR", defaultHTTPAddr),
+		HTTPPath:  envOrDefault("MCP_HTTP_PATH", defaultHTTPPath),
+		AuthToken: os.Getenv("MCP_AUTH_TOKEN"),
+	}
+
+	switch cfg.Transport {
+	case transportStdio:
+		return cfg, nil
+	case transportStreamableHTTP:
+		if cfg.AuthToken == "" {
+			return transportConfig{}, fmt.Errorf("MCP_AUTH_TOKEN is required when MCP_TRANSPORT=%s", transportStreamableHTTP)
+		}
+		if !strings.HasPrefix(cfg.HTTPPath, "/") || cfg.HTTPPath == "/" {
+			return transportConfig{}, fmt.Errorf("MCP_HTTP_PATH must start with / and cannot be /")
+		}
+		if cfg.HTTPPath == "/healthz" {
+			return transportConfig{}, fmt.Errorf("MCP_HTTP_PATH cannot be /healthz")
+		}
+		return cfg, nil
+	default:
+		return transportConfig{}, fmt.Errorf("unsupported MCP_TRANSPORT %q (supported: %s, %s)", cfg.Transport, transportStdio, transportStreamableHTTP)
+	}
+}
+
+func envOrDefault(name, fallback string) string {
+	if value := os.Getenv(name); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func serveMCP(mcpServer *server.MCPServer, cfg transportConfig) error {
+	switch cfg.Transport {
+	case transportStdio:
+		return server.ServeStdio(mcpServer)
+	case transportStreamableHTTP:
+		return serveStreamableHTTP(mcpServer, cfg)
+	default:
+		return fmt.Errorf("unsupported MCP transport %q", cfg.Transport)
+	}
+}
+
+func serveStreamableHTTP(mcpServer *server.MCPServer, cfg transportConfig) error {
+	mcpHandler := server.NewStreamableHTTPServer(
+		mcpServer,
+		server.WithStateLess(true),
+	)
+
+	mux := http.NewServeMux()
+	mux.Handle(cfg.HTTPPath, requireBearerToken(cfg.AuthToken, mcpHandler))
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok\n"))
+	})
+
+	httpServer := &http.Server{
+		Addr:              cfg.HTTPAddr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		IdleTimeout:       2 * time.Minute,
+	}
+	return httpServer.ListenAndServe()
+}
+
+func requireBearerToken(token string, next http.Handler) http.Handler {
+	expectedTokenHash := sha256.Sum256([]byte(token))
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		scheme, providedToken, ok := strings.Cut(r.Header.Get("Authorization"), " ")
+		providedTokenHash := sha256.Sum256([]byte(providedToken))
+		if !ok || !strings.EqualFold(scheme, "Bearer") || subtle.ConstantTimeCompare(providedTokenHash[:], expectedTokenHash[:]) != 1 {
+			w.Header().Set("WWW-Authenticate", "Bearer")
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
## Summary

- preserve stdio as the default transport and add configurable stateless Streamable HTTP support
- protect `/mcp` with a required Bearer token and expose an unauthenticated `/healthz` endpoint
- document local `.mcp.json` configuration and remote Docker deployment