### PR TITLE
feat: inject build version metadata

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,11 +40,22 @@ jobs:
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
 
+    - name: Collect build information
+      id: build-info
+      run: |
+        echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        echo "revision=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+        echo "build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
     - name: Build and push Docker image
       uses: docker/build-push-action@v7
       with:
         context: .
         push: true
+        build-args: |
+          VERSION=${{ steps.build-info.outputs.version }}
+          REVISION=${{ steps.build-info.outputs.revision }}
+          BUILD_DATE=${{ steps.build-info.outputs.build_date }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM golang:1.26-alpine AS builder
 
+ARG VERSION=dev
+ARG REVISION=unknown
+ARG BUILD_DATE=unknown
+
 WORKDIR /app
 
 # Copy go mod files
@@ -12,7 +16,9 @@ RUN go mod download
 COPY . .
 
 # Build the application
-RUN CGO_ENABLED=0 GOOS=linux go build -o miniflux-mcp .
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags "-X main.Version=${VERSION} -X main.Revision=${REVISION} -X main.BuildDate=${BUILD_DATE}" \
+    -o miniflux-mcp .
 
 FROM alpine:latest
 

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,16 @@ E2E_COMPOSE_FILE := .github/e2e/compose.yml
 E2E_DOCKER_ARCH = $(shell docker version --format '{{.Server.Arch}}')
 E2E_PLATFORM = $(if $(filter arm64 aarch64,$(E2E_DOCKER_ARCH)),linux/arm64,linux/amd64)
 E2E_COMPOSE = env DOCKER_DEFAULT_PLATFORM=$(E2E_PLATFORM) $(DOCKER_COMPOSE) -p $(E2E_PROJECT) -f $(E2E_COMPOSE_FILE)
+E2E_VERSION ?= e2e
+VERSION ?= $(shell git describe --tags --always --dirty)
+REVISION ?= $(shell git rev-parse --short HEAD)
+BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+LDFLAGS = -X main.Version=$(VERSION) -X main.Revision=$(REVISION) -X main.BuildDate=$(BUILD_DATE)
 
 .PHONY: build test lint e2e
 
 build:
-	$(GO) build ./...
+	$(GO) build -ldflags "$(LDFLAGS)" ./...
 
 test:
 	$(GO) test ./...
@@ -29,8 +34,9 @@ e2e:
 		$(E2E_COMPOSE) logs; \
 		exit 1; \
 	fi; \
-	$(GO) build -o "$$test_dir/miniflux-mcp" .; \
+	$(GO) build -ldflags "-X main.Version=$(E2E_VERSION)" -o "$$test_dir/miniflux-mcp" .; \
 	if ! MCP_SERVER_PATH="$$test_dir/miniflux-mcp" \
+		EXPECTED_SERVER_VERSION=$(E2E_VERSION) \
 		MINIFLUX_URL=http://localhost:8080 \
 		MINIFLUX_USERNAME=admin \
 		MINIFLUX_PASSWORD=test123 \

--- a/e2e/mcp_test.go
+++ b/e2e/mcp_test.go
@@ -41,6 +41,13 @@ type toolCallResult struct {
 	IsError bool `json:"isError"`
 }
 
+type initializeResult struct {
+	ProtocolVersion string `json:"protocolVersion"`
+	ServerInfo      struct {
+		Version string `json:"version"`
+	} `json:"serverInfo"`
+}
+
 type httpRPCClient struct {
 	endpoint string
 	token    string
@@ -239,9 +246,7 @@ func TestMCPServerWithMiniflux(t *testing.T) {
 	})
 
 	client := &rpcClient{input: stdin, output: bufio.NewReader(stdout)}
-	var initialized struct {
-		ProtocolVersion string `json:"protocolVersion"`
-	}
+	var initialized initializeResult
 	if err := client.request("initialize", map[string]any{
 		"protocolVersion": "2024-11-05",
 		"capabilities":    map[string]any{},
@@ -254,6 +259,9 @@ func TestMCPServerWithMiniflux(t *testing.T) {
 	}
 	if initialized.ProtocolVersion == "" {
 		t.Fatal("initialize response did not include a protocol version")
+	}
+	if initialized.ServerInfo.Version != os.Getenv("EXPECTED_SERVER_VERSION") {
+		t.Fatalf("initialize server version = %q, want %q", initialized.ServerInfo.Version, os.Getenv("EXPECTED_SERVER_VERSION"))
 	}
 	if err := client.notify("notifications/initialized"); err != nil {
 		t.Fatalf("send initialized notification: %v", err)
@@ -428,9 +436,7 @@ func TestRemoteMCPServerWithMiniflux(t *testing.T) {
 		token:    token,
 		client:   httpClient,
 	}
-	var initialized struct {
-		ProtocolVersion string `json:"protocolVersion"`
-	}
+	var initialized initializeResult
 	if err := client.request("initialize", map[string]any{
 		"protocolVersion": "2024-11-05",
 		"capabilities":    map[string]any{},
@@ -443,6 +449,9 @@ func TestRemoteMCPServerWithMiniflux(t *testing.T) {
 	}
 	if initialized.ProtocolVersion == "" {
 		t.Fatal("initialize response did not include a protocol version")
+	}
+	if initialized.ServerInfo.Version != os.Getenv("EXPECTED_SERVER_VERSION") {
+		t.Fatalf("initialize server version = %q, want %q", initialized.ServerInfo.Version, os.Getenv("EXPECTED_SERVER_VERSION"))
 	}
 	if err := client.notify("notifications/initialized"); err != nil {
 		t.Fatalf("send initialized notification: %v", err)

--- a/main.go
+++ b/main.go
@@ -695,11 +695,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("Invalid transport configuration: %v", err)
 	}
+	log.Printf("Starting miniflux-mcp version=%s revision=%s build_date=%s", Version, Revision, BuildDate)
 
 	minifluxServer := NewMinifluxServer()
 	mcpServer := server.NewMCPServer(
 		"miniflux-mcp",
-		"0.1.0",
+		Version,
 		server.WithLogging(),
 	)
 	minifluxServer.RegisterAllTools(mcpServer)

--- a/version.go
+++ b/version.go
@@ -1,0 +1,10 @@
+package main
+
+var (
+	// Version is the version of the compiled software.
+	Version = "dev"
+	// Revision is the short commit hash of the source tree.
+	Revision = "unknown"
+	// BuildDate is the UTC date when the binary was built.
+	BuildDate = "unknown"
+)


### PR DESCRIPTION
## Summary

- inject version, revision, and build date into binaries at link time
- report the injected version through MCP server information and include build metadata in startup logs
- derive release metadata in Docker tag builds and local Makefile builds