### PR TITLE
Reduce get_feeds response size

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The unauthenticated health endpoint is available at `/healthz`. For deployment o
 The Miniflux MCP Server provides **40+ tools** covering all Miniflux API functionality, which can be found in the [Miniflux API Reference](https://miniflux.app/docs/api.html#go-client).
 
 ### Feed Management (11 tools)
-- `get_feeds` - Get all RSS/Atom feeds
+- `get_feeds` - List RSS/Atom feeds with their IDs, titles, feed URLs, disabled status, and categories
 - `get_feed` - Get a specific feed by ID
 - `create_feed` - Add a new RSS/Atom feed
 - `update_feed` - Update an existing feed

--- a/feeds_test.go
+++ b/feeds_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"miniflux.app/v2/client"
+)
+
+func TestGetFeedsReturnsCompactSummaries(t *testing.T) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/v1/feeds" {
+			t.Errorf("path = %s, want /v1/feeds", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"id":                    42,
+				"title":                 "Weather",
+				"feed_url":              "https://example.com/feed.xml",
+				"disabled":              true,
+				"parsing_error_message": strings.Repeat("long parsing error ", 100),
+				"scraper_rules":         "article",
+				"username":              "feed-user",
+				"password":              "feed-password",
+				"category": map[string]any{
+					"id":      7,
+					"title":   "News",
+					"user_id": 1,
+				},
+			},
+			{
+				"id":                    43,
+				"title":                 "Uncategorized",
+				"parsing_error_message": "another error",
+			},
+		}); err != nil {
+			t.Errorf("encode response body: %v", err)
+		}
+	}))
+	defer apiServer.Close()
+
+	minifluxServer := &MinifluxServer{client: client.NewClient(apiServer.URL, "test-api-key")}
+	result, err := minifluxServer.GetFeeds(context.Background(), mcp.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("GetFeeds returned error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("GetFeeds returned tool error: %#v", result.Content)
+	}
+	if len(result.Content) != 1 {
+		t.Fatalf("result content length = %d, want 1", len(result.Content))
+	}
+
+	textContent, ok := mcp.AsTextContent(result.Content[0])
+	if !ok {
+		t.Fatalf("result content type = %T, want text", result.Content[0])
+	}
+
+	const expected = `[
+  {
+    "id": 42,
+    "title": "Weather",
+    "feed_url": "https://example.com/feed.xml",
+    "disabled": true,
+    "category": {
+      "id": 7,
+      "title": "News"
+    }
+  },
+  {
+    "id": 43,
+    "title": "Uncategorized",
+    "feed_url": "",
+    "disabled": false
+  }
+]`
+	if textContent.Text != expected {
+		t.Errorf("GetFeeds result = %s, want %s", textContent.Text, expected)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -16,6 +16,19 @@ type MinifluxServer struct {
 	client *client.Client
 }
 
+type feedSummary struct {
+	ID       int64                `json:"id"`
+	Title    string               `json:"title"`
+	FeedURL  string               `json:"feed_url"`
+	Disabled bool                 `json:"disabled"`
+	Category *feedCategorySummary `json:"category,omitempty"`
+}
+
+type feedCategorySummary struct {
+	ID    int64  `json:"id"`
+	Title string `json:"title"`
+}
+
 func NewMinifluxServer() *MinifluxServer {
 	// Get configuration from environment variables
 	baseURL := os.Getenv("MINIFLUX_URL")
@@ -56,12 +69,33 @@ func NewMinifluxServer() *MinifluxServer {
 }
 
 func (s *MinifluxServer) GetFeeds(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	feeds, err := s.client.Feeds()
+	feeds, err := s.client.FeedsContext(ctx)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to fetch feeds: %v", err)), nil
 	}
 
-	feedsJSON, err := json.MarshalIndent(feeds, "", "  ")
+	summaries := make([]feedSummary, 0, len(feeds))
+	for _, feed := range feeds {
+		if feed == nil {
+			continue
+		}
+
+		summary := feedSummary{
+			ID:       feed.ID,
+			Title:    feed.Title,
+			FeedURL:  feed.FeedURL,
+			Disabled: feed.Disabled,
+		}
+		if feed.Category != nil {
+			summary.Category = &feedCategorySummary{
+				ID:    feed.Category.ID,
+				Title: feed.Category.Title,
+			}
+		}
+		summaries = append(summaries, summary)
+	}
+
+	feedsJSON, err := json.MarshalIndent(summaries, "", "  ")
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal feeds: %v", err)), nil
 	}

--- a/tools.go
+++ b/tools.go
@@ -16,7 +16,7 @@ func (s *MinifluxServer) RegisterAllTools(mcpServer *server.MCPServer) {
 		{
 			Tool: mcp.Tool{
 				Name:        "get_feeds",
-				Description: "Get all RSS/Atom feeds from Miniflux",
+				Description: "List RSS/Atom feeds with their IDs, titles, feed URLs, disabled status, and categories. Use get_feed to retrieve full details for a specific feed.",
 				InputSchema: mcp.ToolInputSchema{
 					Type:       "object",
 					Properties: map[string]interface{}{},


### PR DESCRIPTION
## Summary

- Return compact feed summaries with only the ID, title, feed URL, disabled status, and category
- Direct callers to `get_feed` when full feed details are needed
- Add regression coverage for verbose fields such as parsing error messages
- Fixes #31