### PR TITLE
Reduce repeated feed metadata in entry lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ The unauthenticated health endpoint is available at `/healthz`. For deployment o
 
 The Miniflux MCP Server provides **40+ tools** covering all Miniflux API functionality, which can be found in the [Miniflux API Reference](https://miniflux.app/docs/api.html#go-client).
 
+Entry lists (`get_entries`, `get_feed_entries`, and `get_category_entries`) retain article content, metadata, and pagination totals, but return only compact nested feed metadata: `id`, `title`, `feed_url`, `disabled`, and category `id`/`title` when available. Use `get_feed` for full feed details, including configuration and parsing errors.
+
 ### Feed Management (11 tools)
 - `get_feeds` - List RSS/Atom feeds with their IDs, titles, feed URLs, disabled status, and categories
 - `get_feed` - Get a specific feed by ID

--- a/entries_test.go
+++ b/entries_test.go
@@ -6,11 +6,102 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"miniflux.app/v2/client"
 )
+
+func TestEntryListsUseCompactFeeds(t *testing.T) {
+	feed := &client.Feed{
+		ID: 42, Title: "Weather", FeedURL: "https://example.com/feed", Disabled: true,
+		Category:        &client.Category{ID: 7, Title: "News", UserID: 1},
+		ParsingErrorMsg: strings.Repeat("fetch failed ", 100), ParsingErrorCount: 3,
+		ScraperRules: "article", Cookie: "session=secret", Username: "user", Password: "secret",
+	}
+	entry := &client.Entry{
+		ID: 123, FeedID: 42, UserID: 1, Feed: feed, Title: "Forecast",
+		Content: "<p>Full article content</p>", URL: "https://example.com/article",
+		CommentsURL: "https://example.com/comments", Author: "Author", Status: "unread",
+		Starred: true, Tags: []string{"weather"}, ReadingTime: 5, Language: "en",
+		Date:       time.Date(2026, 9, 4, 0, 0, 0, 0, time.UTC),
+		Enclosures: client.Enclosures{&client.Enclosure{ID: 2, URL: "https://example.com/audio", MimeType: "audio/mpeg"}},
+	}
+	for _, method := range []struct {
+		name string
+		path string
+		call func(*MinifluxServer, context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error)
+	}{
+		{"get_entries", "/v1/entries", (*MinifluxServer).GetEntries},
+		{"get_feed_entries", "/v1/feeds/42/entries", (*MinifluxServer).GetFeedEntries},
+		{"get_category_entries", "/v1/categories/7/entries", (*MinifluxServer).GetCategoryEntries},
+	} {
+		t.Run(method.name, func(t *testing.T) {
+			for _, fixture := range []struct {
+				name    string
+				entries client.Entries
+			}{
+				{"populated", client.Entries{entry, &client.Entry{ID: 124, FeedID: 43}, nil}},
+				{"empty", client.Entries{}},
+				{"null", nil},
+			} {
+				t.Run(fixture.name, func(t *testing.T) {
+					upstream := &client.EntryResultSet{Total: 50, Entries: fixture.entries}
+					payload, err := json.Marshal(upstream)
+					if err != nil {
+						t.Fatal(err)
+					}
+					var expected map[string]any
+					if err := json.Unmarshal(payload, &expected); err != nil {
+						t.Fatal(err)
+					}
+					if fixture.name == "populated" {
+						expected["entries"].([]any)[0].(map[string]any)["feed"] = map[string]any{
+							"id": float64(42), "title": "Weather", "feed_url": "https://example.com/feed", "disabled": true,
+							"category": map[string]any{"id": float64(7), "title": "News"},
+						}
+					}
+					apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						if r.Method != http.MethodGet || r.URL.Path != method.path {
+							t.Errorf("request = %s %s, want GET %s", r.Method, r.URL.Path, method.path)
+						}
+						if r.URL.Query().Get("limit") != "3" || r.URL.Query().Get("status") != "unread" {
+							t.Errorf("filters not preserved: %s", r.URL.RawQuery)
+						}
+						w.Header().Set("Content-Type", "application/json")
+						if _, err := w.Write(payload); err != nil {
+							t.Error(err)
+						}
+					}))
+					defer apiServer.Close()
+					s := &MinifluxServer{client: client.NewClient(apiServer.URL, "test-api-key")}
+					result, err := method.call(s, context.Background(), mcp.CallToolRequest{Params: mcp.CallToolParams{
+						Arguments: map[string]any{"feed_id": float64(42), "category_id": float64(7), "limit": float64(3), "status": "unread"},
+					}})
+					if err != nil {
+						t.Fatal(err)
+					}
+					if result.IsError || len(result.Content) != 1 {
+						t.Fatalf("unexpected tool result: %#v", result)
+					}
+					content, ok := mcp.AsTextContent(result.Content[0])
+					if !ok {
+						t.Fatalf("expected text, got %T", result.Content[0])
+					}
+					var actual map[string]any
+					if err := json.Unmarshal([]byte(content.Text), &actual); err != nil {
+						t.Fatal(err)
+					}
+					if !reflect.DeepEqual(actual, expected) {
+						t.Error("entry list must preserve article fields, total, and null/empty values while replacing nested feed with its compact summary")
+					}
+				})
+			}
+		})
+	}
+}
 
 func TestGetEntriesFilters(t *testing.T) {
 	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/handlers.go
+++ b/handlers.go
@@ -207,7 +207,7 @@ func (s *MinifluxServer) GetFeedEntries(ctx context.Context, request mcp.CallToo
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to fetch feed entries: %v", err)), nil
 	}
 
-	entriesJSON, err := json.MarshalIndent(entries, "", "  ")
+	entriesJSON, err := marshalEntryList(entries)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal entries: %v", err)), nil
 	}

--- a/main.go
+++ b/main.go
@@ -80,19 +80,7 @@ func (s *MinifluxServer) GetFeeds(ctx context.Context, request mcp.CallToolReque
 			continue
 		}
 
-		summary := feedSummary{
-			ID:       feed.ID,
-			Title:    feed.Title,
-			FeedURL:  feed.FeedURL,
-			Disabled: feed.Disabled,
-		}
-		if feed.Category != nil {
-			summary.Category = &feedCategorySummary{
-				ID:    feed.Category.ID,
-				Title: feed.Category.Title,
-			}
-		}
-		summaries = append(summaries, summary)
+		summaries = append(summaries, *summarizeFeed(feed))
 	}
 
 	feedsJSON, err := json.MarshalIndent(summaries, "", "  ")
@@ -196,7 +184,7 @@ func (s *MinifluxServer) GetEntries(ctx context.Context, request mcp.CallToolReq
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to fetch entries: %v", err)), nil
 	}
 
-	entriesJSON, err := json.MarshalIndent(entries, "", "  ")
+	entriesJSON, err := marshalEntryList(entries)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal entries: %v", err)), nil
 	}
@@ -666,7 +654,7 @@ func (s *MinifluxServer) GetCategoryEntries(ctx context.Context, request mcp.Cal
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to fetch category entries: %v", err)), nil
 	}
 
-	entriesJSON, err := json.MarshalIndent(entries, "", "  ")
+	entriesJSON, err := marshalEntryList(entries)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal entries: %v", err)), nil
 	}

--- a/responses.go
+++ b/responses.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"encoding/json"
+
+	"miniflux.app/v2/client"
+)
+
+func summarizeFeed(feed *client.Feed) *feedSummary {
+	if feed == nil {
+		return nil
+	}
+	summary := &feedSummary{
+		ID: feed.ID, Title: feed.Title, FeedURL: feed.FeedURL, Disabled: feed.Disabled,
+	}
+	if feed.Category != nil {
+		summary.Category = &feedCategorySummary{ID: feed.Category.ID, Title: feed.Category.Title}
+	}
+	return summary
+}
+
+// Embed the original entry to preserve article fields, overriding only its feed.
+type entryWithCompactFeed struct {
+	*client.Entry
+	Feed *feedSummary `json:"feed,omitempty"`
+}
+
+func marshalEntryList(result *client.EntryResultSet) ([]byte, error) {
+	if result == nil {
+		return json.MarshalIndent(result, "", "  ")
+	}
+	var entries []*entryWithCompactFeed
+	if result.Entries != nil {
+		entries = make([]*entryWithCompactFeed, len(result.Entries))
+		for i, entry := range result.Entries {
+			if entry != nil {
+				entries[i] = &entryWithCompactFeed{Entry: entry, Feed: summarizeFeed(entry.Feed)}
+			}
+		}
+	}
+	return json.MarshalIndent(struct {
+		*client.EntryResultSet
+		Entries []*entryWithCompactFeed `json:"entries"`
+	}{EntryResultSet: result, Entries: entries}, "", "  ")
+}

--- a/tools.go
+++ b/tools.go
@@ -235,7 +235,7 @@ func (s *MinifluxServer) RegisterAllTools(mcpServer *server.MCPServer) {
 		{
 			Tool: mcp.Tool{
 				Name:        "get_feed_entries",
-				Description: "Get entries from a specific feed",
+				Description: "Get entries from a specific feed, including article content and compact feed metadata. Use get_feed for full feed details.",
 				InputSchema: mcp.ToolInputSchema{
 					Type: "object",
 					Properties: map[string]interface{}{
@@ -321,7 +321,7 @@ func (s *MinifluxServer) RegisterAllTools(mcpServer *server.MCPServer) {
 		{
 			Tool: mcp.Tool{
 				Name:        "get_entries",
-				Description: "Get entries (articles) from Miniflux with optional filtering",
+				Description: "Get entries (articles) from Miniflux with optional filtering, including article content and compact feed metadata. Use get_feed for full feed details.",
 				InputSchema: mcp.ToolInputSchema{
 					Type: "object",
 					Properties: map[string]interface{}{
@@ -600,7 +600,7 @@ func (s *MinifluxServer) RegisterAllTools(mcpServer *server.MCPServer) {
 		{
 			Tool: mcp.Tool{
 				Name:        "get_category_entries",
-				Description: "Get all entries in a specific category",
+				Description: "Get all entries in a specific category, including article content and compact feed metadata. Use get_feed for full feed details.",
 				InputSchema: mcp.ToolInputSchema{
 					Type: "object",
 					Properties: map[string]interface{}{


### PR DESCRIPTION
## Summary

Entry lists repeat full feed configuration for every article, consuming unnecessary context. Reuse the compact feed summary in `get_entries`, `get_feed_entries`, and `get_category_entries`, while preserving article content, metadata, pagination totals, and empty/null values. Full feed details remain available through `get_feed`.

Addresses the [follow-up report in #31](https://github.com/tssujt/miniflux-mcp/issues/31#issuecomment-5546434577).
